### PR TITLE
add agent cycle logging, fix skill tool wiring

### DIFF
--- a/examples/main.js
+++ b/examples/main.js
@@ -177,7 +177,10 @@ function renderToolList() {
 
 renderToolList();
 function getEnabledSkills() {
-	return skills.filter((skill) => enabledSkills.has(skill.name));
+	const enabledChildCallables = getEnabledTools();
+	return skills
+		.filter((skill) => enabledSkills.has(skill.name))
+		.map((skill) => skill.withCallables(enabledChildCallables));
 }
 
 function getEnabledTools() {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -303,6 +303,10 @@ export async function* runAgent(
 		}
 	}
 	history.push({ role: "user", content: input });
+	if (!skipActiveRuns) {
+		console.log("[agent] start");
+		console.log(`[agent] user ${input}`);
+	}
 	let sawError = false;
 	const callableMap = new Map<string, Callable>();
 	for (const callable of callables) {
@@ -351,6 +355,7 @@ export async function* runAgent(
 			for await (const event of stream) {
 				if (E.isLeft(event)) {
 					sawError = true;
+					console.error(`[agent] error ${event.left.message}`);
 					yield event;
 					return;
 				}
@@ -366,6 +371,9 @@ export async function* runAgent(
 
 			const thinkingEvent = flushThinking(stepState);
 			if (thinkingEvent) {
+				console.log(
+					`[agent] thinking.summary tokens=${Math.ceil(thinkingEvent.summary.trim().length / 4)} ${thinkingEvent.summary}`
+				);
 				yield right(thinkingEvent);
 			}
 
@@ -385,6 +393,7 @@ export async function* runAgent(
 					const resolved = resolveTarget(call, args);
 					if (E.isLeft(resolved)) {
 						sawError = true;
+						console.error(`[agent] error ${resolved.left.message}`);
 						yield left(resolved.left);
 						return;
 					}
@@ -410,6 +419,7 @@ export async function* runAgent(
 						}
 						if (E.isLeft(value)) {
 							sawError = true;
+							console.error(`[agent] error ${value.left.message}`);
 							yield value;
 							return;
 						}
@@ -430,6 +440,7 @@ export async function* runAgent(
 			if (content) {
 				history.push({ role: "assistant", content });
 				if (!stepState.sawMessage) {
+					console.log(`[agent] assistant ${content}`);
 					yield right({ type: "message", content });
 				}
 				break;
@@ -440,6 +451,9 @@ export async function* runAgent(
 	} finally {
 		if (!skipActiveRuns && controller && activeRuns.get(history) === controller) {
 			activeRuns.delete(history);
+		}
+		if (!skipActiveRuns) {
+			console.log(`[agent] done hasError=${sawError} aborted=${runSignal?.aborted ?? false}`);
 		}
 	}
 	if (!sawError) {

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -70,13 +70,20 @@ export const applyStreamEvent = (
 			state.textBuffer += event.delta;
 			return { outcome: "continue", outputs: [event] };
 		case "message":
+			console.log(`[agent] assistant ${event.content}`);
 			state.finalText = event.content;
 			state.sawMessage = true;
 			return { outcome: "continue", outputs: [event] };
 		case "thinking.delta":
+			console.log(
+				`[agent] thinking.delta tokens=${Math.ceil(event.delta.trim().length / 4)} ${event.delta}`
+			);
 			state.reasoningSummaryBuffer += event.delta;
 			return { outcome: "continue", outputs: [event] };
 		case "thinking":
+			console.log(
+				`[agent] thinking.summary tokens=${Math.ceil(event.summary.trim().length / 4)} ${event.summary}`
+			);
 			state.finalReasoningSummary = event.summary;
 			state.sawThinking = true;
 			return { outcome: "continue", outputs: [event] };
@@ -215,6 +222,14 @@ export async function* runToolCall(
 	basePrompt: string,
 	loopMessages: Message[]
 ): AsyncGenerator<AgentStreamEvent, StreamOutcome, void> {
+	if (target.kind === "skill") {
+		console.log(`[agent] skill.start ${call.name}`, {
+			callId: call.id,
+			args,
+		});
+	} else {
+		console.log(`[agent] tool.start ${call.name}`, { callId: call.id, args });
+	}
 	yield right(toolStartEvent(call, args, target));
 	if (target.kind === "skill") {
 		const result = await runSkill(target, ctx, signal, maxSteps, generate, runAgent, basePrompt);
@@ -225,6 +240,9 @@ export async function* runToolCall(
 		for (const event of result.right.events) {
 			yield right(event);
 		}
+		console.log(`[agent] skill.end ${call.name}`, {
+			result: result.right.output,
+		});
 		yield right(toolEndEvent(call, result.right.output, target));
 		addToolOutput(loopMessages, call.id ?? "tool-call", result.right.output ?? null);
 		return "continue";
@@ -237,6 +255,7 @@ export async function* runToolCall(
 		yield left(result.left);
 		return "error";
 	}
+	console.log(`[agent] tool.end ${call.name}`, { result: result.right });
 	yield right(toolEndEvent(call, result.right, target));
 	addToolOutput(loopMessages, call.id ?? "tool-call", result.right ?? null);
 	return "continue";


### PR DESCRIPTION
- В демо исправлен вызов canvas_render (в скилл прокидываются активные тулы)
- Добавлено логирование агентского цикла через console.log/console.error в ключевых точках: user/assistant, thinking, tool/skill start/end, done/error.

<img width="1280" height="649" alt="image" src="https://github.com/user-attachments/assets/99762e6a-7ab2-4099-a0e0-7b5c083708be" />
